### PR TITLE
Reduce stress on VBox controller (startup burst + send pacing)

### DIFF
--- a/custom_components/vitrea/hub.py
+++ b/custom_components/vitrea/hub.py
@@ -1,5 +1,6 @@
 """Vitrea Hub class."""
 
+import asyncio
 import logging
 from numbers import Number
 
@@ -276,7 +277,12 @@ class VitreaHub:
                         add_timer=key_type == VitreaKeyTypes.Boiler.value,
                     )
                     self.devices[device._id] = device
-                    await device.get_state()
+                    # NOTE: Per-key GetKeyStatus is intentionally NOT requested here.
+                    # VBoxController.connect() already issued GetFullStatusCommand
+                    # (H:NALL:G) which returns the state of every key/output. Sending
+                    # a GetKeyStatus per device on top of that produced a large burst
+                    # (one request per light/switch/cover) that overwhelmed the VBox
+                    # controller on systems with many devices.
         for scenario in data.get("scenarios", []):
             room = scenario.get("room", None)
             if not room:
@@ -305,7 +311,11 @@ class VitreaHub:
                 append_room_to_name=self.append_room_name,
             )
             self.hvacs[tmst._id] = tmst
+            # Thermostats are not covered by GetFullStatus (H:NALL:G), so we
+            # still request their state individually. Space these requests
+            # out to avoid bursting the controller when many HVACs exist.
             await tmst.get_state()
+            await asyncio.sleep(0.1)
 
     @property
     def hub_id(self) -> str:

--- a/custom_components/vitrea/vitrea_integration/vbox_connection.py
+++ b/custom_components/vitrea/vitrea_integration/vbox_connection.py
@@ -38,6 +38,7 @@ class VBoxConnection:
         connection_callback: Callable | None = None,
         event_beat_seconds: int = 0.2,
         enabled=True,
+        min_send_interval: float = 0.08,
     ) -> None:
         self.ip = ip
         self.port = port
@@ -45,6 +46,10 @@ class VBoxConnection:
         self.writer = None
         self.command_queue: asyncio.Queue[bytes] = asyncio.Queue()
         self.event_beat_seconds = event_beat_seconds
+        # Minimum delay between two outbound frames. Vitrea VBox controllers
+        # can be overwhelmed by back-to-back commands (e.g. startup bursts),
+        # so the writer loop enforces this floor between sends.
+        self.min_send_interval = max(0.0, float(min_send_interval))
         self._connected = False
         self._last_keep_alive = None
         self.response_callback = response_callback
@@ -54,6 +59,9 @@ class VBoxConnection:
         self.last_keep_alive_sent = None
         self._connected_lock = threading.Lock()
         self._task_lock = threading.Lock()
+        # Serialize all actual socket writes so the writer loop and the
+        # monitor-loop keep-alive cannot interleave bytes on the wire.
+        self._send_lock = asyncio.Lock()
         # Timestamps and diagnostics
         self.last_rx = None
         self.last_tx = None
@@ -326,7 +334,13 @@ class VBoxConnection:
         _LOGGER.debug("Reader loop finished")
 
     async def _writer_loop(self) -> None:
-        """Continuously send queued commands to the controller."""
+        """Continuously send queued commands to the controller.
+
+        Enforces a minimum interval between outgoing frames so we do not
+        flood the VBox controller during startup bursts or rapid HA service
+        calls. The pacing is based on ``self.last_tx`` which is updated by
+        ``_send`` for both queued commands and keep-alive frames.
+        """
 
         while self.enabled and not self._stop_event.is_set():
             try:
@@ -338,8 +352,14 @@ class VBoxConnection:
 
             if not command:
                 continue
+
+            if self.min_send_interval and self.last_tx is not None:
+                elapsed = (datetime.now() - self.last_tx).total_seconds()
+                remaining = self.min_send_interval - elapsed
+                if remaining > 0:
+                    await asyncio.sleep(remaining)
+
             await self._send(command)
-            continue 
 
         _LOGGER.debug("Writer loop finished")
 
@@ -373,15 +393,20 @@ class VBoxConnection:
         _LOGGER.debug("Monitor loop finished")
 
     async def _send(self, command: bytes) -> bool:
-        """Send a command to the VBox."""
-        _LOGGER.debug(("sending(ascii):", command))
-        _LOGGER.debug(("sending(hex):", command.hex()))
-        if not self.writer:
-            raise ConnectionError("Connection is not available")
-        self.writer.write(command)
-        await self.writer.drain()
-        self.last_tx = datetime.now()
-        _LOGGER.debug("Command sent to VBox")
+        """Send a command to the VBox.
+
+        Serialized by ``_send_lock`` so the writer-loop and the monitor-loop
+        keep-alive cannot interleave bytes on the wire.
+        """
+        async with self._send_lock:
+            _LOGGER.debug(("sending(ascii):", command))
+            _LOGGER.debug(("sending(hex):", command.hex()))
+            if not self.writer:
+                raise ConnectionError("Connection is not available")
+            self.writer.write(command)
+            await self.writer.drain()
+            self.last_tx = datetime.now()
+            _LOGGER.debug("Command sent to VBox")
         return True
 
     async def _receive(self):

--- a/custom_components/vitrea/vitrea_integration/vbox_controller.py
+++ b/custom_components/vitrea/vitrea_integration/vbox_controller.py
@@ -38,17 +38,23 @@ class VBoxController:
         self,
         ip: str,
         port: int,
-        event_beat_seconds: int = 0.02,
-        thread_beat_seconds: int = 0.05,
+        event_beat_seconds: float = 0.1,
+        thread_beat_seconds: float = 0.05,
         status_update_callback=None,
         enabled=True,
+        min_send_interval: float = 0.08,
     ):
+        # event_beat_seconds previously defaulted to 0.02s which caused the
+        # reader/writer idle paths to spin very tightly. 0.1s is plenty
+        # responsive for a serial-style RS-485 gateway and noticeably
+        # reduces CPU + chance of write/read races.
         self.connection = VBoxConnection(
             ip=ip,
             port=port,
             event_beat_seconds=event_beat_seconds,
             connection_callback=self._connection_change_callback,
             response_callback=self.on_response,
+            min_send_interval=min_send_interval,
         )
         self.id = None
         self.communication_lock = asyncio.Lock()


### PR DESCRIPTION
## Summary

Reduces stress on the VBox controller, which can become unresponsive when the integration bursts many commands back-to-back. No behavior change for normal HA service calls beyond a small minimum interval between frames.

- **Drop redundant startup burst.** `VBoxController.connect()` already issues `GetFullStatusCommand` (`H:NALL:G`) which returns state for every key/output, but `hub._get_devices` was then calling `await device.get_state()` for every light/switch/cover/push-button — each sending its own `GetKeyStatus` (`H:N{node}:G:{key}`). On configurations with many devices this produced dozens of frames in a single millisecond right after discovery, which by itself was enough to wedge the controller. Per-thermostat `get_state()` is kept (the full-status command does not cover thermostats) with a small `asyncio.sleep(0.1)` between HVACs.
- **Serialize the actual socket write.** Added an `asyncio.Lock` (`_send_lock`) wrapping `writer.write` / `drain` in `VBoxConnection._send`. Previously the writer loop and the monitor-loop keep-alive both called `_send` from independent tasks with no lock, so their bytes could interleave on the wire.
- **Add minimum inter-command spacing.** New `min_send_interval` (default `0.08s`) enforced in `_writer_loop` based on `last_tx`. Prevents flooding the controller during startup bursts or rapid HA service calls. The monitor keep-alive bypasses the queue and is unaffected.
- **Reduce idle-loop spin.** Default `event_beat_seconds` raised from `0.02` to `0.1`. The reader/writer idle paths previously spun at 50 Hz which wasted CPU and tightened write/read races without any benefit for a serial-style RS-485 gateway.
- Small cleanups: removed a stray double `continue` in `_writer_loop`, corrected the `event_beat_seconds` / `thread_beat_seconds` type annotations from `int` to `float` (they were already being assigned floats).

## Test plan

Verified on a live HAOS install with the Vitrea integration controlling lights, blinds, switches and thermostats:

- [x] Startup: only the parameter-API discovery frames followed by a single `H:NALL:G` are sent; the previous per-key burst is gone.
- [x] Discovery frames are now spaced ~80 ms apart instead of 1–4 ms apart.
- [x] Keep-alives continue at the normal 20 s cadence with no overlap with other writes.
- [x] A multi-device automation (6 blind/toggle commands queued from a scene) was sent at ~80 ms intervals and completed without any reader timeouts, reconnects, or controller stalls.
- [x] No errors, warnings, or exceptions logged from `custom_components.vitrea` over the test period.
